### PR TITLE
Added manifest.yml and .cfignore for use on PaaS

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,1 @@
+.gitignore

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,5 @@
+---
+applications:
+- name: tv-signs
+  memory: 128M
+  buildpack: ruby_buildpack


### PR DESCRIPTION
## What
If we decide to run this on the PaaS we need to have a manifest.yml and a .cfignore file to specify the buildpack and what not to upload to the PaaS.

## How to test

Deploy it on the PaaS with `cf push tv-signs` then verify with the generated URL in a browser.

## Who can review?

Not me